### PR TITLE
Making all log file names the same

### DIFF
--- a/awslogs.conf
+++ b/awslogs.conf
@@ -5,7 +5,7 @@ state_file = /var/awslogs/state/agent-state
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /var/log/syslog
 buffer_duration = 5000
-log_stream_name = {instance_id}-{hostname}-{ip_address}-syslog
+log_stream_name = syslog
 initial_position = start_of_file
 log_group_name = ecs
 
@@ -13,7 +13,7 @@ log_group_name = ecs
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /var/log/kern.log
 buffer_duration = 5000
-log_stream_name = {instance_id}-{hostname}-{ip_address}-kern.log
+log_stream_name = kern.log
 initial_position = start_of_file
 log_group_name = ecs
 
@@ -21,7 +21,7 @@ log_group_name = ecs
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /mnt/ecs_instance_logs/docker
 buffer_duration = 5000
-log_stream_name = {instance_id}-{hostname}-{ip_address}-docker
+log_stream_name = docker
 initial_position = start_of_file
 log_group_name = ecs
 
@@ -29,7 +29,7 @@ log_group_name = ecs
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /mnt/ecs_instance_logs/ecs/ecs-agent.log
 buffer_duration = 5000
-log_stream_name = {instance_id}-{hostname}-{ip_address}-ecs-agent.log
+log_stream_name = ecs-agent.log
 initial_position = start_of_file
 log_group_name = ecs
 
@@ -37,15 +37,15 @@ log_group_name = ecs
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /mnt/ecs_instance_logs/ecs/ecs-init.log
 buffer_duration = 5000
-log_stream_name = {instance_id}-{hostname}-{ip_address}-ecs-init.log
+log_stream_name = ecs-init.log
 initial_position = start_of_file
-log_group_name = ecs 
+log_group_name = ecs
 
 [httpd-access.log]
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /var/log/httpd-access.log
 buffer_duration = 5000
-log_stream_name = {instance_id}-{hostname}-{ip_address}-httpd-access.log
+log_stream_name = httpd-access.log
 initial_position = start_of_file
 log_group_name = ecs
 
@@ -53,6 +53,6 @@ log_group_name = ecs
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /var/log/httpd-error.log
 buffer_duration = 5000
-log_stream_name = {instance_id}-{hostname}-{ip_address}-httpd-error.log
+log_stream_name = httpd-error.log
 initial_position = start_of_file
 log_group_name = ecs


### PR DESCRIPTION
This will allow all instance logs to go to the same file. We will add uniqueness by specifying information in the `logger` command.
